### PR TITLE
Support passing a socket to the driver creator

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,9 @@ Cycle.run(computer, {
     socketIO: socketIODriver
 });
 ```
+
+##API
+
+### createSocketIODriver(socket|url)
+
+Creates a socket.io driver which uses the provided socket, or initializes a socket to the given url if a string is passed

--- a/dist/script.js
+++ b/dist/script.js
@@ -14,8 +14,10 @@ var _socketIoClient = require('socket.io-client');
 
 var _socketIoClient2 = _interopRequireDefault(_socketIoClient);
 
-function createSocketIODriver(url) {
-    var socket = (0, _socketIoClient2['default'])(url);
+function createSocketIODriver(socket) {
+    if (typeof socket === 'string') {
+        socket = (0, _socketIoClient2['default'])(socket);
+    }
 
     function get(eventName) {
         return _rx2['default'].Observable.create(function (observer) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,10 @@
 import Rx from 'rx';
 import io from 'socket.io-client';
 
-function createSocketIODriver(url) {
-    const socket = io(url);
+function createSocketIODriver(socket) {
+    if (typeof socket === 'string') {
+        socket = io(socket);
+    }
 
     function get(eventName) {
         return Rx.Observable.create(observer => {


### PR DESCRIPTION
The socket.io client creator accepts many other parameters other than `url`, such as `reconnection`, etc., which are not currently supported.
Also, you might not want to have the socket encapsulated inside the driver.
