### PR TITLE
Allow socket.io ^1.3.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": "Chris Marasti-Georg",
   "license": "ISC",
   "peerDependencies": {
-    "socket.io-client": "1.3.7",
+    "socket.io-client": "^1.3.7",
     "rx": "^4.0.7"
   },
   "devDependencies": {


### PR DESCRIPTION
There is nothing about cycle-socket.io that is incompatible with socket.io-client 1.4.x, so allow those versions to be compatible too
