### PR TITLE
Support all xstream versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "Chris Marasti-Georg",
   "license": "ISC",
   "peerDependencies": {
-    "xstream": "^10"
+    "xstream": "*"
   },
   "devDependencies": {
     "babel": "^5.0.0"


### PR DESCRIPTION
Since `xstream@11` was released, add support for it.

`@cycle/dom` supports `xstream` with a `*` peerDependency, so I guess it is safe to take the same approach here:
https://github.com/cyclejs/cyclejs/blob/master/dom/package.json